### PR TITLE
Use ampersand as option delimiter

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,6 @@ idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEn
 # HL7-MLLP Route
 idaas.connect.consumer.hl7-mllp.scheme=netty:tcp
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
-idaas.connect.consumer.hl7-mllp.options=sync=true,encoders=#hl7encoder,decoders=#hl7decoder
+idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
 idaas.connect.producer.hl7-mllp.0.scheme=stub
 idaas.connect.producer.hl7-mllp.0.context=hl7-stub

--- a/src/test/java/com/redhat/idaas/connect/configuration/PropertyParserTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/PropertyParserTest.java
@@ -2,9 +2,13 @@ package com.redhat.idaas.connect.configuration;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.model.RoutesDefinition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,5 +68,15 @@ public class PropertyParserTest {
 
         expectedValue = "org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory";
         Assertions.assertEquals(expectedValue, actualComponents.get("hl7encoder"));
+    }
+
+    /**
+     * Tests {@link PropertyParser#PropertyParser(Properties)} and validates route generation
+     * TODO: more comprehensive testing in a separate test class with camel-test
+     */
+    @Test
+    public void testPropertyParserRoutes() {
+        List<RouteBuilder> actualRoutes = propertyParser.getIdaasRouteDefinitions();
+        Assertions.assertEquals(1, actualRoutes.size());
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,7 +5,7 @@ idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEn
 # HL7-MLLP Route
 idaas.connect.consumer.hl7-mllp.scheme=netty:tcp
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
-idaas.connect.consumer.hl7-mllp.options=sync=true,encoders=#hl7encoder,decoders=#hl7decoder
+idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
 idaas.connect.producer.hl7-mllp.0.scheme=stub
 idaas.connect.producer.hl7-mllp.0.context=hl7-stub
 


### PR DESCRIPTION
Fixes Issue #21 

This PR:
- utilizes the ampersand as the endpoint option delimiter
- adds logging to generate routes
- cleans up some variable naming