### PR TITLE
PropertyParser updates to support variation in Camel Component URIs

### DIFF
--- a/src/main/java/com/redhat/idaas/connect/configuration/CamelEndpoint.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/CamelEndpoint.java
@@ -17,7 +17,7 @@ final class CamelEndpoint {
 
     private String contextPath;
 
-    private final Map<String, String> options = new HashMap<>();
+    private String options;
 
     String getScheme() {
         return scheme;
@@ -35,14 +35,9 @@ final class CamelEndpoint {
         this.contextPath = contextPath;
     }
 
-    /**
-     * Adds an endpoint option
-     * @param optionName The option name
-     * @param optionValue The option value
-     */
-    void addOption(String optionName, String optionValue) {
-        options.put(optionName, optionValue);
-    }
+    String getOptions() { return options; }
+
+    void setOptions(String options) { this.options = options; }
 
     /**
      * Determines if this CamelEndpoint instance is equal to another object.
@@ -74,37 +69,21 @@ final class CamelEndpoint {
     }
 
     /**
-     * @return the string representation for this endpoint
+     * @return the URI string representation for this endpoint
      */
     @Override
     public String toString() {
-        StringBuilder endpoint = new StringBuilder();
+        StringBuilder endpointUri = new StringBuilder();
         String scheme = getScheme() == null ? "" : getScheme();
-        String uri = getContextPath() == null ? "" : getContextPath();
+        String context = getContextPath() == null ? "" : getContextPath();
 
-        if (!scheme.endsWith(":")) {
-            scheme += ":";
+        endpointUri.append(scheme)
+            .append(context);
+
+        if (options != null && options.length()  > 1) {
+            endpointUri.append("?");
+            endpointUri.append(options);
         }
-
-        endpoint.append(scheme);
-
-        if (!uri.startsWith("//")) {
-            uri = "//" + uri;
-        }
-
-        endpoint.append(uri);
-
-        if (options.size() > 0) {
-            endpoint.append("?");
-
-            for (Entry<String, String> optionEntry : options.entrySet()) {
-                endpoint.append(optionEntry.getKey());
-                endpoint.append("=");
-                endpoint.append(optionEntry.getValue());
-                endpoint.append("&");
-            }
-            endpoint.setLength(endpoint.length() - 1);
-        }
-        return endpoint.toString();
+        return endpointUri.toString();
     }
 }

--- a/src/main/java/com/redhat/idaas/connect/configuration/PropertyParser.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/PropertyParser.java
@@ -129,13 +129,7 @@ public final class PropertyParser {
         } else if (endpointField.equalsIgnoreCase("context")) {
             camelEndpoint.setContextPath(fieldValue);
         } else if (endpointField.equalsIgnoreCase("options")) {
-
-            // options are comma delimited
-            for (String option : fieldValue.split("&")) {
-                // each option is formatted as key=value
-                String[] optionTokens = option.split("=");
-                camelEndpoint.addOption(optionTokens[0], optionTokens[1]);
-            }
+            camelEndpoint.setOptions(fieldValue);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,8 +3,8 @@ idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDe
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 
 # HL7-MLLP Route
-idaas.connect.consumer.hl7-mllp.scheme=netty:tcp
+idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
 idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-idaas.connect.producer.hl7-mllp.0.scheme=stub
+idaas.connect.producer.hl7-mllp.0.scheme=stub://
 idaas.connect.producer.hl7-mllp.0.context=hl7-stub

--- a/src/test/java/com/redhat/idaas/connect/configuration/CamelEndpointTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/CamelEndpointTest.java
@@ -19,7 +19,7 @@ public class CamelEndpointTest {
     @BeforeEach
     public void beforeEach() {
         camelEndpoint = new CamelEndpoint();
-        camelEndpoint.setScheme("ftp");
+        camelEndpoint.setScheme("ftp://");
         camelEndpoint.setContextPath("myftp.com:21/dropbox");
     }
 
@@ -108,20 +108,10 @@ public class CamelEndpointTest {
      */
     @Test
     public void testToStringWithOptions() {
-        camelEndpoint.addOption("binary", "true");
-        camelEndpoint.addOption("disconnect", "true");
-        camelEndpoint.addOption("transferLoggingLevel", "ERROR");
+        camelEndpoint.setOptions("binary=true&disconnect=true&transferLoggingLevel=ERROR");
 
-        // order of parameters is not deterministic
-        String actual = camelEndpoint.toString();
-        String[] options = actual.split("\\?");
-        Assertions.assertEquals(2, options.length);
-
-        options = actual.split("\\?")[1].split("&");
-        Assertions.assertEquals(3, options.length);
-
-        Arrays.sort(options);
-        String[] expectedOptions = {"binary=true", "disconnect=true", "transferLoggingLevel=ERROR"};
-        Assertions.assertArrayEquals(expectedOptions, options);
+        String expectedUri = "ftp://myftp.com:21/dropbox?binary=true&disconnect=true&transferLoggingLevel=ERROR";
+        String actualUri = camelEndpoint.toString();
+        Assertions.assertEquals(expectedUri, actualUri);
     }
 }

--- a/src/test/java/com/redhat/idaas/connect/configuration/CamelRouteTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/CamelRouteTest.java
@@ -20,14 +20,14 @@ public class CamelRouteTest {
         camelRoute.setRouteId("myRoute");
 
         CamelEndpoint consumer = new CamelEndpoint();
-        consumer.setScheme("ftp");
+        consumer.setScheme("ftp://");
         consumer.setContextPath("myftp.com:22/dropbox");
         camelRoute.setConsumer(consumer);
 
         CamelEndpoint producer = new CamelEndpoint();
-        producer.setScheme("file");
+        producer.setScheme("file://");
         producer.setContextPath("home/serviceuser/documents");
-        producer.addOption("fileExist", "FAIL");
+        producer.setOptions("fileExist=FAIL");
         camelRoute.addProducer(producer);
     }
 
@@ -110,7 +110,7 @@ public class CamelRouteTest {
                 .concat(".to(file://home/serviceuser/documents?fileExist=FAIL,file://home/otheruser)\n");
 
         CamelEndpoint producer = new CamelEndpoint();
-        producer.setScheme("file");
+        producer.setScheme("file://");
         producer.setContextPath("home/otheruser");
         camelRoute.addProducer(producer);
 

--- a/src/test/java/com/redhat/idaas/connect/configuration/PropertyParserTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/PropertyParserTest.java
@@ -7,8 +7,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.RouteDefinition;
-import org.apache.camel.model.RoutesDefinition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,10 +3,10 @@ idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDe
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 
 # HL7-MLLP Route
-idaas.connect.consumer.hl7-mllp.scheme=netty:tcp
+idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
 idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-idaas.connect.producer.hl7-mllp.0.scheme=stub
+idaas.connect.producer.hl7-mllp.0.scheme=stub://
 idaas.connect.producer.hl7-mllp.0.context=hl7-stub
 
 some.other.property=value


### PR DESCRIPTION
Fixes #24 

This PR updates the PropertyParser by removing some of the "auto-generated" convenience of generating an endpoint URI string. Specifically:

- The parser will no longer add a separator between the scheme and context
- Route "options" are now evaluated literally

This places a bit more work, if you can call it that, on the user that is generating the properties, but the trade-off is that we will have wider Camel Component support since we aren't making any assumptions, and users are free to enter in the component specific configuration items.