### PR TITLE
Route Processing Enhancements

### DIFF
--- a/src/main/java/com/redhat/idaas/connect/App.java
+++ b/src/main/java/com/redhat/idaas/connect/App.java
@@ -1,6 +1,8 @@
 package com.redhat.idaas.connect;
 
+import com.redhat.idaas.connect.configuration.CamelRoute;
 import com.redhat.idaas.connect.configuration.PropertyParser;
+import com.redhat.idaas.connect.route.RouteGenerator;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
 import org.slf4j.Logger;
@@ -9,8 +11,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 /**
@@ -58,8 +60,11 @@ public final class App {
         Map<String, String> componentMap = propertyParser.getIdaasComponents();
         addCamelComponents(componentMap);
 
-        List<RouteBuilder> routes = propertyParser.getIdaasRouteDefinitions();
-        routes.forEach(r -> camelMain.configure().addRoutesBuilder(r));
+        for (Entry<String, CamelRoute> entry: propertyParser.getIdaasRoutes().entrySet()) {
+            RouteGenerator routeGenerator = new RouteGenerator(entry.getValue());
+            RouteBuilder routeBuilder = routeGenerator.generate();
+            camelMain.configure().addRoutesBuilder(routeBuilder);
+        }
     }
 
     /**

--- a/src/main/java/com/redhat/idaas/connect/configuration/CamelEndpoint.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/CamelEndpoint.java
@@ -6,9 +6,9 @@ import java.util.Objects;
  * Models a Camel Java DSL endpoint.
  * A Java DSL endpoint may be a consumer or producer within a Camel Route.
  * The Java DSL endpoint format is a URI structured as [scheme]://[contextPath]?[options]
- * Options are separated by "&"
+ * Options are usually separated by "&"
  */
-final class CamelEndpoint {
+public final class CamelEndpoint {
 
     private String scheme;
 
@@ -16,25 +16,25 @@ final class CamelEndpoint {
 
     private String options;
 
-    String getScheme() {
+    public String getScheme() {
         return scheme;
     }
 
-    void setScheme(String scheme) {
+    public void setScheme(String scheme) {
         this.scheme = scheme;
     }
 
-    String getContextPath() {
+    public String getContextPath() {
         return contextPath;
     }
 
-    void setContextPath(String contextPath) {
+    public void setContextPath(String contextPath) {
         this.contextPath = contextPath;
     }
 
-    String getOptions() { return options; }
+    public String getOptions() { return options; }
 
-    void setOptions(String options) { this.options = options; }
+    public void setOptions(String options) { this.options = options; }
 
     /**
      * Determines if this CamelEndpoint instance is equal to another object.

--- a/src/main/java/com/redhat/idaas/connect/configuration/CamelRoute.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/CamelRoute.java
@@ -1,43 +1,38 @@
 package com.redhat.idaas.connect.configuration;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
  * Models a Camel Java DSL Route.
  * A Camel Java DSL Route has a consumer and one or more producers.
+ * The route also stores the name of the blue print used to construct it.
  */
-final class CamelRoute {
+public final class CamelRoute {
 
     private String routeId;
 
+    private String routeBluePrint;
+
     private CamelEndpoint consumer = new CamelEndpoint();
 
-    private List<CamelEndpoint> producers = new ArrayList<>();
-
-    void setRouteId(String routeId) {
+    public void setRouteId(String routeId) {
         this.routeId = routeId;
     }
 
-    String getRouteId() {
+    public String getRouteId() {
         return routeId;
     }
 
-    CamelEndpoint getConsumer() {
+    public void setRouteBluePrint(String routeBluePrint) { this.routeBluePrint = routeBluePrint; }
+
+    public String getRouteBluePrint() { return routeBluePrint; }
+
+    public CamelEndpoint getConsumer() {
         return consumer;
     }
 
-    void setConsumer(CamelEndpoint consumer) {
+    public void setConsumer(CamelEndpoint consumer) {
         this.consumer = consumer;
-    }
-
-    List<CamelEndpoint> getProducers() {
-        return producers;
-    }
-
-    void addProducer(CamelEndpoint producer) {
-        producers.add(producer);
     }
 
     /**
@@ -66,35 +61,5 @@ final class CamelRoute {
     @Override
     public int hashCode() {
         return Objects.hash(getRouteId());
-    }
-
-    /**
-     * @return the Java DSL string representation for this route
-     */
-    @Override
-    public String toString() {
-        StringBuilder route = new StringBuilder();
-        route.append("from(")
-                .append(consumer.toString())
-                .append(")\n")
-                .append(".routeId(")
-                .append(getRouteId())
-                .append(")\n");
-
-        if (producers.size() == 1) {
-            route.append(".to(")
-                    .append(producers.get(0).toString())
-                    .append(")\n");
-        } else if (producers.size() > 1) {
-            route.append(".multicast()\n");
-            route.append(".to(");
-            for (CamelEndpoint producer : producers) {
-                route.append(producer.toString())
-                        .append(",");
-            }
-            route.setLength(route.length() - 1);
-            route.append(")\n");
-        }
-        return route.toString();
     }
 }

--- a/src/main/java/com/redhat/idaas/connect/configuration/PropertyParser.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/PropertyParser.java
@@ -1,47 +1,21 @@
 package com.redhat.idaas.connect.configuration;
 
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.RouteDefinition;
-
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 
 /**
  * Parses iDAAS Connect Application Properties used to generate Camel components, routes, and processors.
- * iDAAS properties
- * iDAAS property format
- * Components:
- * - [idaas namespace].component.[component name]=[component class]
- * - idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
- *
- * Consumer Endpoints:
- * - [idaas namespace].consumer.[route id].[scheme|context|options]
- * - idaas.connect.consumer.hl7-mllp.scheme=netty:tcp
- *
- * Producer Endpoints:
- * - [idaas namespace].producer.[route id].[zero based producer id].[scheme|context|options]
- * - idaas.connect.producer.hl7-mllp.0.scheme=stub
  */
 public final class PropertyParser {
 
     // constants used to parse property keys
-    private static final String IDAAS_NAMESPACE_PROPERTY = "idaas.connect.namespace";
-    private static final String DEFAULT_IDAAS_PROPERTY_NAMESPACE = "idaas.connect";
+    private static final String IDAAS_PROPERTY_NAMESPACE = "idaas.connect";
+    private static final String IDAAS_ROUTE_NAMESPACE = "route";
     private static final String IDAAS_COMPONENT_NAMESPACE = "component";
     private static final String IDAAS_CONSUMER_NAMESPACE = "consumer";
-    private static final String IDAAS_PRODUCER_NAMESPACE = "producer";
-
-    /**
-     * the namespace, or prefix, used to filter idaas connect properties
-     */
-    private final String idaasPropertyNamespace;
 
     /**
      * properties object containing idaas connect properties
@@ -59,14 +33,10 @@ public final class PropertyParser {
     private final Map<String, CamelRoute> idaasRoutes = new HashMap<>();
 
     /**
-     * Camel {@link RouteBuilder} instances used to construct a {@link RouteDefinition}
-     */
-    private final List<RouteBuilder> idaasRouteDefinitions = new ArrayList<>();
-
-    /**
      * Returns a map of iDAAS Components
      * Key - component name
      * Value - component class name
+     *
      * @return iDAAS Components as {@link Map}
      */
     public Map<String, String> getIdaasComponents() {
@@ -77,50 +47,31 @@ public final class PropertyParser {
      * Returns a map of iDAAS Routes
      * Key - route id
      * Value - {@link CamelRoute}
+     *
      * @return iDAAS Route as {@link Map}
      */
-    private Map<String, CamelRoute> getIdaasRoutes() { return idaasRoutes; }
-
-    /**
-     * Returns the Camel {@link RouteBuilder} used to construct the processing routes declared
-     * in iDAAS {@link Properties}
-     * @return {@link List}
-     */
-    public List<RouteBuilder> getIdaasRouteDefinitions() { return idaasRouteDefinitions; }
+    public Map<String, CamelRoute> getIdaasRoutes() {
+        return idaasRoutes;
+    }
 
     /**
      * Parses the component identifier and value (component class name) from a property name and value.
-     * @param propertyName The property name
+     *
+     * @param propertyKey   The property key
      * @param propertyValue The property value (component class name)
      */
-    private void parseComponent(String propertyName, String propertyValue) {
-        int componentNameIndex = propertyName.lastIndexOf('.') + 1;
-        String componentKey = propertyName.substring(componentNameIndex);
+    private void parseComponent(String propertyKey, String propertyValue) {
+        int componentNameIndex = propertyKey.lastIndexOf('.') + 1;
+        String componentKey = propertyKey.substring(componentNameIndex);
         idaasComponents.put(componentKey, propertyValue);
     }
 
     /**
-     * Parses a route id from a consumer or producer endpoint.
-     * @param propertyName The idaas property name/key
-     * @param propertyValue The idaas property value
-     */
-    private void parseRouteId(String propertyName, String propertyValue) {
-        String routeId =  propertyName
-                .substring(idaasPropertyNamespace.length() + 1)
-                .split("\\.")[1];
-
-        if (!idaasRoutes.containsKey(routeId)) {
-            CamelRoute camelRoute = new CamelRoute();
-            camelRoute.setRouteId(routeId);
-            idaasRoutes.put(routeId, camelRoute);
-        }
-    }
-
-    /**
      * Sets a {@link CamelEndpoint} field
+     *
      * @param camelEndpoint The target CamelEndpoint
      * @param endpointField The field to set
-     * @param fieldValue The field value
+     * @param fieldValue    The field value
      */
     private void setEndpointField(CamelEndpoint camelEndpoint, String endpointField, String fieldValue) {
 
@@ -134,113 +85,61 @@ public final class PropertyParser {
     }
 
     /**
+     * Parses route configuration fields
+     *
+     * @param routeId       The route id
+     * @param propertyField The route configuration property field
+     * @param propertyValue The route configuration property value
+     */
+    private void parseRoute(String routeId, String propertyField, String propertyValue) {
+        if (propertyField.endsWith("blueprint")) {
+            idaasRoutes.get(routeId).setRouteBluePrint(propertyValue);
+        }
+    }
+
+    /**
      * Parses a consumer endpoint property
-     * @param propertyName The property name/key
+     *
+     * @param routeId       The route id
+     * @param propertyField The property name/key
      * @param propertyValue The property value
      */
-    private void parseConsumer(String propertyName, String propertyValue) {
-        String consumerNamespace = idaasPropertyNamespace
-                .concat(".")
-                .concat(IDAAS_CONSUMER_NAMESPACE);
-
-        String[] consumerFields = propertyName
-                .substring(consumerNamespace.length() + 1)
-                .split("\\.");
-
-        String routeId = consumerFields[0];
-        String consumerField = consumerFields[1];
-
+    private void parseConsumer(String routeId, String propertyField, String propertyValue) {
         CamelEndpoint consumer = idaasRoutes.get(routeId).getConsumer();
-        setEndpointField(consumer, consumerField, propertyValue);
+        setEndpointField(consumer, propertyField, propertyValue);
     }
 
     /**
-     * Parses a producer endpoint property
-     * @param propertyName The property name/key
-     * @param propertyValue The property value
-     */
-    private void parseProducer(String propertyName, String propertyValue) {
-        String producerNamespace = idaasPropertyNamespace
-                .concat(".")
-                .concat(IDAAS_PRODUCER_NAMESPACE);
-
-        String[] producerFields = propertyName
-                .substring(producerNamespace.length() + 1)
-                .split("\\.");
-
-        String routeId = producerFields[0];
-        int producerIndex = Integer.parseInt(producerFields[1]);
-        String producerField = producerFields[2];
-
-        List<CamelEndpoint> producers = idaasRoutes.get(routeId).getProducers();
-        CamelEndpoint producer;
-
-        if (producerIndex != producers.size() -1) {
-            producer = new CamelEndpoint();
-            producers.add(producer);
-        } else {
-            producer = idaasRoutes.get(routeId).getProducers().get(producerIndex);
-        }
-
-        setEndpointField(producer, producerField, propertyValue);
-    }
-
-    /**
-     * Parses Camel {@link RouteBuilder} from property metadata
-     */
-    private void parseRoutes() {
-        for (Entry<String, CamelRoute> routeEntry: idaasRoutes.entrySet()) {
-            CamelRoute camelRoute = routeEntry.getValue();
-
-            idaasRouteDefinitions.add(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    CamelEndpoint consumer = camelRoute.getConsumer();
-
-                    if (camelRoute.getProducers().size() == 1) {
-                        CamelEndpoint producer = camelRoute.getProducers().get(0);
-                        from(consumer.toString())
-                                .routeId(camelRoute.getRouteId())
-                                .log(LoggingLevel.INFO, "${body}")
-                                .to(producer.toString());
-                    } else {
-                        String producerUris = camelRoute.getProducers()
-                                .stream()
-                                .map(CamelEndpoint::toString)
-                                .collect(Collectors.joining(","));
-                        from(consumer.toString())
-                                .routeId(camelRoute.getRouteId())
-                                .log(LoggingLevel.INFO, "${body}")
-                                .multicast()
-                                .to(producerUris);
-                    }
-                }
-            });
-        }
-    }
-
-    /**
-     * Parses application properties, generating application metadata for Camel components.
+     * Parses application properties into domain models, generating application metadata for Camel components.
      */
     private void parseProperties() {
-        for (String propertyName : idaasProperties.stringPropertyNames()) {
-            String propertyValue = idaasProperties.getProperty(propertyName);
+        for (String propertyKey : idaasProperties.stringPropertyNames()) {
+            String propertyValue = idaasProperties.getProperty(propertyKey);
 
-            int namespaceStartIndex = idaasPropertyNamespace.length() + 1;
-            int namespaceEndIndex = namespaceStartIndex + propertyName.substring(namespaceStartIndex).indexOf('.');
-            String propertyNamespace = propertyName.substring(namespaceStartIndex, namespaceEndIndex);
+            int namespaceStartIndex = IDAAS_PROPERTY_NAMESPACE.length() + 1;
+            int namespaceEndIndex = namespaceStartIndex + propertyKey.substring(namespaceStartIndex).indexOf('.');
+            String propertyNamespace = propertyKey.substring(namespaceStartIndex, namespaceEndIndex);
+
+            if (propertyNamespace.equalsIgnoreCase(IDAAS_COMPONENT_NAMESPACE)) {
+                parseComponent(propertyKey, propertyValue);
+                continue;
+            }
+
+            String[] tokens = propertyKey.substring(namespaceEndIndex + 1).split("\\.");
+            String routeId = tokens[0];
+            String propertyField = tokens[1];
+
+            if (!idaasRoutes.containsKey(routeId)) {
+                CamelRoute camelRoute = new CamelRoute();
+                camelRoute.setRouteId(routeId);
+                idaasRoutes.put(routeId, camelRoute);
+            }
 
             switch (propertyNamespace) {
-                case IDAAS_COMPONENT_NAMESPACE:
-                    parseComponent(propertyName, propertyValue);
-                    break;
+                case IDAAS_ROUTE_NAMESPACE:
+                    parseRoute(routeId, propertyField, propertyValue);
                 case IDAAS_CONSUMER_NAMESPACE:
-                    parseRouteId(propertyName, propertyValue);
-                    parseConsumer(propertyName, propertyValue);
-                    break;
-                case IDAAS_PRODUCER_NAMESPACE:
-                    parseRouteId(propertyName, propertyValue);
-                    parseProducer(propertyName, propertyValue);
+                    parseConsumer(routeId, propertyField, propertyValue);
                     break;
             }
         }
@@ -259,15 +158,14 @@ public final class PropertyParser {
     /**
      * Filters properties by matching on a string prefix.
      *
-     * @param properties   The source Properties
-     * @param filterPrefix The prefix used to match the properties
+     * @param properties The source Properties
      * @return a Properties instance containing properties which match the string prefix
      */
-    private Properties filterProperties(Properties properties, String filterPrefix) {
+    private Properties filterProperties(Properties properties) {
         Map<Object, Object> filteredProperties = properties
                 .entrySet()
                 .stream()
-                .filter(p -> p.getKey().toString().startsWith(filterPrefix))
+                .filter(p -> p.getKey().toString().startsWith(IDAAS_PROPERTY_NAMESPACE))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         Properties idaasProperties = new Properties();
@@ -279,13 +177,11 @@ public final class PropertyParser {
      * Creates a new PropertyParser instance.
      * Incoming properties are filtered to include properties which are used to generate Camel
      * components, routes, and processors.
+     *
      * @param properties The source application properties
      */
     public PropertyParser(Properties properties) {
-        idaasPropertyNamespace = properties.getProperty(IDAAS_NAMESPACE_PROPERTY, DEFAULT_IDAAS_PROPERTY_NAMESPACE);
-        idaasProperties = filterProperties(properties, idaasPropertyNamespace);
+        idaasProperties = filterProperties(properties);
         parseProperties();
-        parseRoutes();
-        idaasRoutes.clear();
     }
 }

--- a/src/main/java/com/redhat/idaas/connect/route/FhirRestBluePrint.java
+++ b/src/main/java/com/redhat/idaas/connect/route/FhirRestBluePrint.java
@@ -1,0 +1,14 @@
+package com.redhat.idaas.connect.route;
+
+import com.redhat.idaas.connect.configuration.CamelRoute;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Creates a route used to parse FHIR Rest Messages.
+ */
+public class FhirRestBluePrint implements RouteBluePrint {
+    @Override
+    public RouteBuilder buildRoute(CamelRoute camelRoute) {
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/idaas/connect/route/Hl7BluePrint.java
+++ b/src/main/java/com/redhat/idaas/connect/route/Hl7BluePrint.java
@@ -1,0 +1,14 @@
+package com.redhat.idaas.connect.route;
+
+import com.redhat.idaas.connect.configuration.CamelRoute;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Creates a route used to parse HL7-MLLP Messages.
+ */
+public class Hl7BluePrint implements RouteBluePrint {
+    @Override
+    public RouteBuilder buildRoute(CamelRoute camelRoute) {
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/idaas/connect/route/RouteBluePrint.java
+++ b/src/main/java/com/redhat/idaas/connect/route/RouteBluePrint.java
@@ -1,0 +1,17 @@
+package com.redhat.idaas.connect.route;
+
+import com.redhat.idaas.connect.configuration.CamelRoute;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Builds a {@link RouteBuilder} Camel Java DSL route from a {@link CamelRoute} domain object
+ */
+public interface RouteBluePrint {
+
+    /**
+     * Constructs a {@link RouteBuilder} instance from a {@link CamelRoute}
+     * @param camelRoute The camel route domain object
+     * @return {@link RouteBuilder} instance
+     */
+    RouteBuilder buildRoute(CamelRoute camelRoute);
+}

--- a/src/main/java/com/redhat/idaas/connect/route/RouteBluePrintFactory.java
+++ b/src/main/java/com/redhat/idaas/connect/route/RouteBluePrintFactory.java
@@ -1,0 +1,32 @@
+package com.redhat.idaas.connect.route;
+
+/**
+ * Creates {@link RouteBluePrint} instances
+ */
+public class RouteBluePrintFactory {
+
+    /**
+     * Creates a {@link RouteBluePrint} instance from a blue print id
+     *
+     * @param bluePrint The blue print id
+     * @return {@link RouteBluePrint}
+     */
+    public static RouteBluePrint getInstance(String bluePrint) {
+        RouteBluePrint routeBluePrint = null;
+
+        if (bluePrint == null) {
+            return null;
+        }
+
+        switch (bluePrint.toLowerCase()) {
+            case "stub":
+                return new StubBluePrint();
+            case "hl7":
+                return new Hl7BluePrint();
+            case "fhir":
+                return new FhirRestBluePrint();
+            default:
+                return routeBluePrint;
+        }
+    }
+}

--- a/src/main/java/com/redhat/idaas/connect/route/RouteGenerator.java
+++ b/src/main/java/com/redhat/idaas/connect/route/RouteGenerator.java
@@ -1,0 +1,30 @@
+package com.redhat.idaas.connect.route;
+
+import com.redhat.idaas.connect.configuration.CamelRoute;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Generates {@link RouteBuilder} instances from a {@link CamelRoute} model
+ */
+public class RouteGenerator {
+
+    private final CamelRoute camelRoute;
+
+    /**
+     * Generates the {@link RouteBuilder} instance
+     * @return {@link RouteBuilder} instance
+     */
+    public RouteBuilder generate() {
+        String routeBluePrint = camelRoute.getRouteBluePrint();
+        RouteBluePrint bluePrint = RouteBluePrintFactory.getInstance(routeBluePrint);
+        return bluePrint.buildRoute(camelRoute);
+    }
+
+    /**
+     * Associates the RouteGenerator with a {@link CamelRoute} instance
+     * @param camelRoute The {@link CamelRoute} instance
+     */
+    public RouteGenerator(CamelRoute camelRoute) {
+        this.camelRoute = camelRoute;
+    }
+}

--- a/src/main/java/com/redhat/idaas/connect/route/StubBluePrint.java
+++ b/src/main/java/com/redhat/idaas/connect/route/StubBluePrint.java
@@ -1,0 +1,25 @@
+package com.redhat.idaas.connect.route;
+
+import com.redhat.idaas.connect.configuration.CamelRoute;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Creates a route with a single Stub producer.
+ */
+public class StubBluePrint implements RouteBluePrint {
+
+    @Override
+    public RouteBuilder buildRoute(CamelRoute camelRoute) {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(camelRoute.getConsumer().toString())
+                    .log(LoggingLevel.DEBUG, "received message")
+                    .log(LoggingLevel.DEBUG, "${body}")
+                        .to("stub://hl7-mllp");
+
+            }
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,8 +3,7 @@ idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDe
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 
 # HL7-MLLP Route
+idaas.connect.route.hl7-mllp.blueprint=stub
 idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
 idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-idaas.connect.producer.hl7-mllp.0.scheme=stub://
-idaas.connect.producer.hl7-mllp.0.context=hl7-stub

--- a/src/test/java/com/redhat/idaas/connect/configuration/CamelEndpointTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/CamelEndpointTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link CamelEndpoint}
  */
-public class CamelEndpointTest {
+class CamelEndpointTest {
 
     private CamelEndpoint camelEndpoint;
 
@@ -15,7 +15,7 @@ public class CamelEndpointTest {
      * Constructs a {@link CamelEndpoint} fixture prior to each test
      */
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         camelEndpoint = new CamelEndpoint();
         camelEndpoint.setScheme("ftp://");
         camelEndpoint.setContextPath("myftp.com:21/dropbox");
@@ -25,7 +25,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#equals} where an instance is compared to itself
      */
     @Test
-    public void testEqualsSameInstance() {
+    void testEqualsSameInstance() {
         CamelEndpoint otherEndpoint = camelEndpoint;
         Assertions.assertEquals(camelEndpoint, otherEndpoint);
     }
@@ -34,7 +34,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#equals} where an instance is compared to null
      */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         Assertions.assertNotEquals(camelEndpoint, null);
     }
 
@@ -42,7 +42,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#equals} where an instance is compared to a non-compatible type
      */
     @Test
-    public void testEqualsDifferentClass() {
+    void testEqualsDifferentClass() {
         Assertions.assertNotEquals(camelEndpoint, "a string");
     }
 
@@ -50,7 +50,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#equals} where an instance is compared to an equivalent object
      */
     @Test
-    public void testEqualsEquivalent() {
+    void testEqualsEquivalent() {
         CamelEndpoint otherEndpoint = new CamelEndpoint();
         otherEndpoint.setScheme(camelEndpoint.getScheme());
         otherEndpoint.setContextPath(camelEndpoint.getContextPath());
@@ -61,7 +61,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#equals} where an instance is compared to a non-equivalent object
      */
     @Test
-    public void testEqualsNotEquivalent() {
+    void testEqualsNotEquivalent() {
         CamelEndpoint otherEndpoint = new CamelEndpoint();
         otherEndpoint.setScheme(camelEndpoint.getScheme());
         otherEndpoint.setContextPath("myftp.com:21/dropoff");
@@ -72,7 +72,7 @@ public class CamelEndpointTest {
      * Validates that {@link CamelEndpoint#hashCode()} generates the same hash code for equivalent objects
      */
     @Test
-    public void testHashCodeForEqualObjects() {
+    void testHashCodeForEqualObjects() {
         CamelEndpoint otherEndpoint = new CamelEndpoint();
         otherEndpoint.setScheme(camelEndpoint.getScheme());
         otherEndpoint.setContextPath(camelEndpoint.getContextPath());
@@ -84,7 +84,7 @@ public class CamelEndpointTest {
      * Validates that {@link CamelEndpoint#hashCode()} generates the same hash code for non-equivalent objects
      */
     @Test
-    public void testHashCodeForNonEqualObjects() {
+    void testHashCodeForNonEqualObjects() {
         CamelEndpoint otherEndpoint = new CamelEndpoint();
         otherEndpoint.setScheme(camelEndpoint.getScheme());
         otherEndpoint.setContextPath("myftp.com:21/dropoff");
@@ -96,7 +96,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#toString()}
      */
     @Test
-    public void testToString() {
+    void testToString() {
         String expectedString = "ftp://myftp.com:21/dropbox";
         Assertions.assertEquals(expectedString, camelEndpoint.toString());
     }
@@ -105,7 +105,7 @@ public class CamelEndpointTest {
      * Tests {@link CamelEndpoint#toString()} when endpoint options are present
      */
     @Test
-    public void testToStringWithOptions() {
+    void testToStringWithOptions() {
         camelEndpoint.setOptions("binary=true&disconnect=true&transferLoggingLevel=ERROR");
 
         String expectedUri = "ftp://myftp.com:21/dropbox?binary=true&disconnect=true&transferLoggingLevel=ERROR";

--- a/src/test/java/com/redhat/idaas/connect/configuration/CamelRouteTest.java
+++ b/src/test/java/com/redhat/idaas/connect/configuration/CamelRouteTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link CamelRoute}
  */
-public class CamelRouteTest {
+class CamelRouteTest {
 
     private CamelRoute camelRoute;
 
@@ -15,27 +15,22 @@ public class CamelRouteTest {
      * Configures the {@link CamelRoute} fixture
      */
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         camelRoute = new CamelRoute();
         camelRoute.setRouteId("myRoute");
+        camelRoute.setRouteBluePrint("StubBluePrint");
 
         CamelEndpoint consumer = new CamelEndpoint();
         consumer.setScheme("ftp://");
         consumer.setContextPath("myftp.com:22/dropbox");
         camelRoute.setConsumer(consumer);
-
-        CamelEndpoint producer = new CamelEndpoint();
-        producer.setScheme("file://");
-        producer.setContextPath("home/serviceuser/documents");
-        producer.setOptions("fileExist=FAIL");
-        camelRoute.addProducer(producer);
     }
 
     /**
      * Tests {@link CamelRoute#equals} where an instance is compared to null
      */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         Assertions.assertNotEquals(camelRoute, null);
     }
 
@@ -43,7 +38,7 @@ public class CamelRouteTest {
      * Tests {@link CamelRoute#equals} where an instance is compared to a non-compatible type
      */
     @Test
-    public void testEqualsDifferentClass() {
+    void testEqualsDifferentClass() {
         Assertions.assertNotEquals(camelRoute, "a string");
     }
 
@@ -51,7 +46,7 @@ public class CamelRouteTest {
      * Tests {@link CamelRoute#equals} where an instance is compared to an equivalent object
      */
     @Test
-    public void testEqualsEquivalent() {
+    void testEqualsEquivalent() {
         CamelRoute otherRoute = new CamelRoute();
         otherRoute.setRouteId(camelRoute.getRouteId());
         Assertions.assertEquals(camelRoute, otherRoute);
@@ -61,7 +56,7 @@ public class CamelRouteTest {
      * Tests {@link CamelRoute#equals} where an instance is compared to a non-equivalent object
      */
     @Test
-    public void testEqualsNotEquivalent() {
+    void testEqualsNotEquivalent() {
         CamelRoute otherRoute = new CamelRoute();
         otherRoute.setRouteId("otherRoute");
         Assertions.assertNotEquals(camelRoute, otherRoute);
@@ -71,7 +66,7 @@ public class CamelRouteTest {
      * Validates that {@link CamelRoute#hashCode()} generates the same hash code for equivalent objects
      */
     @Test
-    public void testHashCodeForEqualObjects() {
+    void testHashCodeForEqualObjects() {
         CamelRoute otherRoute = new CamelRoute();
         otherRoute.setRouteId(camelRoute.getRouteId());
         Assertions.assertEquals(camelRoute.hashCode(), otherRoute.hashCode());
@@ -81,39 +76,9 @@ public class CamelRouteTest {
      * Validates that {@link CamelRoute#hashCode()} generates the same hash code for non-equivalent objects
      */
     @Test
-    public void testHashCodeForNonEqualObjects() {
+    void testHashCodeForNonEqualObjects() {
         CamelRoute otherRoute = new CamelRoute();
         otherRoute.setRouteId("otherRoute");
         Assertions.assertNotEquals(camelRoute.hashCode(), otherRoute.hashCode());
-    }
-
-    /**
-     * Tests {@link CamelRoute#toString()} with a single producer
-     */
-    @Test
-    public void testToString() {
-        String expectedRoute = "from(ftp://myftp.com:22/dropbox)\n"
-                .concat(".routeId(myRoute)\n")
-                .concat(".to(file://home/serviceuser/documents?fileExist=FAIL)\n");
-        Assertions.assertEquals(expectedRoute, camelRoute.toString());
-    }
-
-
-    /**
-     * Tests {@link CamelRoute#toString()} with multiple producers
-     */
-    @Test
-    public void testToStringMultipleProducers() {
-        String expectedRoute = "from(ftp://myftp.com:22/dropbox)\n"
-                .concat(".routeId(myRoute)\n")
-                .concat(".multicast()\n")
-                .concat(".to(file://home/serviceuser/documents?fileExist=FAIL,file://home/otheruser)\n");
-
-        CamelEndpoint producer = new CamelEndpoint();
-        producer.setScheme("file://");
-        producer.setContextPath("home/otheruser");
-        camelRoute.addProducer(producer);
-
-        Assertions.assertEquals(expectedRoute, camelRoute.toString());
     }
 }

--- a/src/test/java/com/redhat/idaas/connect/route/RouteBluePrintFactoryTest.java
+++ b/src/test/java/com/redhat/idaas/connect/route/RouteBluePrintFactoryTest.java
@@ -1,0 +1,52 @@
+package com.redhat.idaas.connect.route;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+/**
+ * Tests {@link RouteBluePrintFactory}
+ */
+class RouteBluePrintFactoryTest {
+
+    /**
+     * Provides arguments to {@link RouteBluePrintFactory#getInstance(String)}
+     *
+     * @return {@link Stream} of arguments
+     */
+    static Stream<Arguments> getInstanceProvider() {
+        return Stream.of(
+                Arguments.arguments("stub", StubBluePrint.class)
+        );
+    }
+
+    /**
+     * Tests {@link RouteBluePrintFactory#getInstance(String)} with a blue print id
+     * @param bluePrintId The blue print id for the lookup
+     * @param expectedClass The expected {@link RouteBluePrint} implementation class
+     */
+    @ParameterizedTest
+    @MethodSource("getInstanceProvider")
+    void testGetInstance(String bluePrintId, Class<? extends RouteBluePrint> expectedClass) {
+        RouteBluePrint actualClass = RouteBluePrintFactory.getInstance(bluePrintId);
+        Assertions.assertNotNull(actualClass);
+        Assertions.assertTrue(expectedClass.isInstance(actualClass));
+    }
+
+    /**
+     * Tests {@link RouteBluePrintFactory#getInstance(String)} for expected null return values
+     */
+    @Test
+    void testGetInstanceNullReturn() {
+        Assertions.assertNull(RouteBluePrintFactory.getInstance(null));
+        Assertions.assertNull(RouteBluePrintFactory.getInstance("foo"));
+    }
+
+
+}
+

--- a/src/test/java/com/redhat/idaas/connect/route/RouteValidationTest.java
+++ b/src/test/java/com/redhat/idaas/connect/route/RouteValidationTest.java
@@ -1,5 +1,6 @@
-package com.redhat.idaas.connect.routes;
+package com.redhat.idaas.connect.route;
 
+import com.redhat.idaas.connect.configuration.CamelRoute;
 import com.redhat.idaas.connect.configuration.PropertyParser;
 import org.apache.camel.Endpoint;
 import org.apache.camel.builder.RouteBuilder;
@@ -20,7 +21,7 @@ import java.util.stream.Stream;
 /**
  * Parametrized Test cases for iDAAS-Connect generated routes.
  */
-public class RouteValidationTest extends CamelTestSupport {
+class RouteValidationTest extends CamelTestSupport {
 
     private static final String PROPERTY_FILE_DIRECTORY = "route-validation-tests/";
 
@@ -58,7 +59,7 @@ public class RouteValidationTest extends CamelTestSupport {
      * @return propertyParser a Property Parser instance
      * @throws Exception if an error occurs during route generation
      */
-    public PropertyParser setupRoutes(String propertyFilePath) throws Exception {
+    PropertyParser setupRoutes(String propertyFilePath) throws Exception {
         Properties properties = loadProperties(propertyFilePath);
         PropertyParser propertyParser = new PropertyParser(properties);
 
@@ -66,7 +67,9 @@ public class RouteValidationTest extends CamelTestSupport {
             registerCamelBean(entry.getKey(), entry.getValue());
         }
 
-        for (RouteBuilder routeBuilder : propertyParser.getIdaasRouteDefinitions()) {
+        for (Entry<String, CamelRoute> entry: propertyParser.getIdaasRoutes().entrySet()) {
+            RouteGenerator routeGenerator = new RouteGenerator(entry.getValue());
+            RouteBuilder routeBuilder = routeGenerator.generate();
             routeBuilder.addRoutesToCamelContext(context);
         }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,10 +3,9 @@ idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDe
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 
 # HL7-MLLP Route
+idaas.connect.route.hl7-mllp.blueprint=stub
 idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
 idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-idaas.connect.producer.hl7-mllp.0.scheme=stub://
-idaas.connect.producer.hl7-mllp.0.context=hl7-stub
 
 some.other.property=value

--- a/src/test/resources/route-validation-tests/hl7-mllp.properties
+++ b/src/test/resources/route-validation-tests/hl7-mllp.properties
@@ -3,8 +3,7 @@ idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDe
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 
 # HL7-MLLP Route
+idaas.connect.route.hl7-mllp.blueprint=stub
 idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
 idaas.connect.consumer.hl7-mllp.context=localhost:2575
 idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-idaas.connect.producer.hl7-mllp.0.scheme=stub://
-idaas.connect.producer.hl7-mllp.0.context=hl7-stub


### PR DESCRIPTION
Fixes #4 

This PR updates the folllowing:
- Property Parsing has been refactored and simplified a bit
- Routes are now generated using a strategy pattern - aka "route blue prints"
- Added a working "stub" blue print id
- Added "stub" blue prints for hl7-mllp and fhir-rest

Note: The properties format has changed. Producers are no longer included in the file as they are provided by the blue print implementations. Post-MVP we can look into supporting "additional" producers other than Kafka and NATS in the configuration

Properties Example:
```
# Processing Components
idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory

# HL7-MLLP Route
idaas.connect.route.hl7-mllp.blueprint=stub
idaas.connect.consumer.hl7-mllp.scheme=netty:tcp://
idaas.connect.consumer.hl7-mllp.context=localhost:2575
idaas.connect.consumer.hl7-mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
```
