### PR TITLE
FHIR R4 Messaging Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,18 +18,29 @@ application {
 
 dependencies {
 
+    // camel libraries
     implementation group: 'org.apache.camel', name: 'camel-core', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-fhir', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-dataformat', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-kafka', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-http', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-jackson', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-jetty', version: project.camelVersion
     implementation group: 'org.apache.camel', name: 'camel-main', version: project.camelVersion
     implementation group: 'org.apache.camel', name: 'camel-nats', version: project.camelVersion
-    implementation group: 'org.apache.camel', name: 'camel-kafka', version: project.camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-rest', version: project.camelVersion
 
+    // data format support
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.jacksonVersion
+
+    // logging
     implementation group: 'org.slf4j', name: 'slf4j-api', version: project.slfjVersion
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: project.slfjVersion
 
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: project.log4jVersion
     implementation group: 'commons-logging', name: 'commons-logging', version: project.commonsVersion
-    
-    // HL7-MLLP
+
+    // HL7-MLLP processing
     implementation group: 'org.apache.camel', name: 'camel-netty', version: project.camelVersion
     implementation group: 'org.apache.camel', name: 'camel-hl7', version: project.camelVersion
     implementation group: 'ca.uhn.hapi', name: 'hapi-structures-v21', version: project.hapiHl7Version
@@ -43,6 +54,11 @@ dependencies {
     implementation group: 'ca.uhn.hapi', name: 'hapi-structures-v27', version: project.hapiHl7Version
     implementation group: 'ca.uhn.hapi', name: 'hapi-structures-v28', version: project.hapiHl7Version
     implementation group: 'ca.uhn.hapi', name: 'hapi-structures-v281', version: project.hapiHl7Version
+
+    // FHIR R4 Processing
+    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-base', version: project.hapiFhirVersion
+    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: project.hapiFhirVersion
+    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-client', version: project.hapiFhirVersion
 
     // testing
     testImplementation group: 'org.apache.camel', name: 'camel-test-junit5', version: project.camelVersion

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: "3.7"
 services:
-  # kafdrop and kafka images provided by https://github.com/obsidiandynamics/kafdrop  
   kafdrop:
     image: obsidiandynamics/kafdrop
     restart: "no"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,14 @@ supportedJavaVersion=1.8
 
 # framework verions
 camelVersion=3.3.0
+jacksonVersion=2.11.0
 junitVersion=5.6.2
 slfjVersion=1.7.30
 
-# hl7 client version
+
+# hapi hl7 and fhir client versions
 hapiHl7Version=2.3
+hapiFhirVersion=5.0.2
 
 # ipfs
 ipfsClientVersion=1.0.0.Beta4

--- a/src/main/java/com/redhat/idaas/connect/builder/FhirR4RestRouteBuilder.java
+++ b/src/main/java/com/redhat/idaas/connect/builder/FhirR4RestRouteBuilder.java
@@ -1,13 +1,33 @@
 package com.redhat.idaas.connect.builder;
 
-import org.apache.camel.builder.RouteBuilder;
+import com.redhat.idaas.connect.configuration.EndpointUriBuilder;
+import org.apache.camel.LoggingLevel;
+
+import java.net.URI;
 
 /**
  * Defines a FHIR R4 REST Processing route
  */
 public class FhirR4RestRouteBuilder extends IdaasRouteBuilder {
-    @Override
-    public void configure() throws Exception {
 
+    @Override
+    public void configure() {
+        EndpointUriBuilder uriBuilder = getEndpointUriBuilder();
+        URI fhirBaseUri = URI.create(uriBuilder.getFhirR4RestUri());
+        String kafkaDataStoreUri = uriBuilder.getDataStoreUri("FHIR_R4_${headers.resourceType.toUpperCase()}");
+
+        restConfiguration()
+                .host(fhirBaseUri.getHost())
+                .port(fhirBaseUri.getPort());
+
+        rest(fhirBaseUri.getPath())
+                .post("/{resource}")
+                .route()
+                .routeId("fhir-r4-rest")
+                .unmarshal().fhirJson("R4")
+                .setHeader("resourceType",simple("${body.resourceType.toString()}"))
+                .marshal().fhirJson("R4")
+                .log(LoggingLevel.INFO, "${body}")
+                .toD(kafkaDataStoreUri);
     }
 }

--- a/src/main/java/com/redhat/idaas/connect/builder/Hl7v2MllpRouteBuilder.java
+++ b/src/main/java/com/redhat/idaas/connect/builder/Hl7v2MllpRouteBuilder.java
@@ -1,22 +1,23 @@
 package com.redhat.idaas.connect.builder;
 
+import com.redhat.idaas.connect.configuration.EndpointUriBuilder;
 import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.kafka.KafkaConstants;
 
 /**
  * Defines a HL7 V2 MLLP processing route
  */
 public class Hl7v2MllpRouteBuilder extends IdaasRouteBuilder {
+
     @Override
     public void configure() {
-        String consumerUri = getHl7V2MllpUri();
-        String producerUri = getDataStoreUri("HL7v2_${headers[CamelHL7MessageType]}");
+        EndpointUriBuilder uriBuilder = getEndpointUriBuilder();
+        String consumerUri = uriBuilder.getHl7V2MllpUri();
+        String producerUri = uriBuilder.getDataStoreUri("HL7v2_${headers[CamelHL7MessageType]}");
 
         from(consumerUri)
                 .routeId("hl7-v2-mllp")
                 .unmarshal().hl7()
-                .log(LoggingLevel.INFO, producerUri)
                 .log(LoggingLevel.INFO, "${body}")
                 .setHeader(KafkaConstants.KEY, constant("Camel"))
                 .toD(producerUri);

--- a/src/main/java/com/redhat/idaas/connect/builder/IdaasRouteBuilder.java
+++ b/src/main/java/com/redhat/idaas/connect/builder/IdaasRouteBuilder.java
@@ -1,7 +1,7 @@
 package com.redhat.idaas.connect.builder;
 
+import com.redhat.idaas.connect.configuration.EndpointUriBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.spi.PropertiesComponent;
 
 /**
  * Base class for iDAAS Route Builder implementations.
@@ -10,41 +10,15 @@ import org.apache.camel.spi.PropertiesComponent;
  */
 public class IdaasRouteBuilder extends RouteBuilder {
 
-    private static final String HL7_V2_MLLP_BASE_URI_PROP_KEY = "idaas.connect.endpoint.hl7_v2_mllp.baseUri";
-    private static final String HL7_V2_MLLP_OPTIONS_PROP_KEY = "idaas.connect.endpoint.hl7_v2_mllp.options";
-
-    private static final String DATA_STORE_BASE_URI_PROP_KEY = "idaas.connect.endpoint.datastore.baseUri";
-    private static final String DATA_STORE_OPTIONS_PROP_KEY = "idaas.connect.endpoint.datastore.options";
-
     /**
-     * @return the HL7 V2 MLLP URI
+     * @return {@link EndpointUriBuilder} used to build endpoint uris for consumers and producers
      */
-    public String getHl7V2MllpUri() {
-        PropertiesComponent properties = getContext().getPropertiesComponent();
-
-        return properties.resolveProperty(HL7_V2_MLLP_BASE_URI_PROP_KEY).orElse("")
-                .concat("?")
-                .concat(properties.resolveProperty(HL7_V2_MLLP_OPTIONS_PROP_KEY).orElse(""));
+    public EndpointUriBuilder getEndpointUriBuilder() {
+        return getContext()
+                .getRegistry()
+                .lookupByNameAndType(EndpointUriBuilder.BEAN_NAME, EndpointUriBuilder.class);
     }
-
-    /**
-     * Builds a data store URI
-     * @param topicName The data store topic/segment for the URI
-     * @return the data store URI
-     */
-    public String getDataStoreUri(String topicName) {
-        PropertiesComponent properties = getContext().getPropertiesComponent();
-
-        return properties
-                .resolveProperty(DATA_STORE_BASE_URI_PROP_KEY).orElse("")
-                .concat(":")
-                .concat(topicName)
-                .concat("?")
-                .concat(properties.resolveProperty(DATA_STORE_OPTIONS_PROP_KEY).orElse(""));
-    }
-
 
     @Override
-    public void configure() throws Exception {}
-
+    public void configure() {}
 }

--- a/src/main/java/com/redhat/idaas/connect/configuration/EndpointUriBuilder.java
+++ b/src/main/java/com/redhat/idaas/connect/configuration/EndpointUriBuilder.java
@@ -1,0 +1,89 @@
+package com.redhat.idaas.connect.configuration;
+
+import java.util.Properties;
+
+/**
+ * Builds Camel Endpoint URIs from application properties
+ */
+public final class EndpointUriBuilder {
+    public static final String BEAN_NAME = "endpointUriBuilder";
+
+    private static final String HL7_V2_MLLP_BASE_URI_PROP_KEY = "idaas.connect.endpoint.hl7_v2_mllp.baseUri";
+    private static final String HL7_V2_MLLP_OPTIONS_PROP_KEY = "idaas.connect.endpoint.hl7_v2_mllp.options";
+
+    private static final String FHIR_R4_REST_BASE_URI_PROP_KEY = "idaas.connect.endpoint.fhir_r4_rest.baseUri";
+
+    private static final String FHIR_R4_EXTERNAL_REST_BASE_URI_PROP_KEY = "idaas.connect.endpoint.external_fhir_r4_rest.baseUri";
+    private static final String FHIR_R4_EXTERNAL_REST_OPTIONS_PROP_KEY = "idaas.connect.endpoint.external_fhir_r4_rest.options";
+
+    private static final String DATA_STORE_BASE_URI_PROP_KEY = "idaas.connect.endpoint.datastore.baseUri";
+    private static final String DATA_STORE_OPTIONS_PROP_KEY = "idaas.connect.endpoint.datastore.options";
+
+    private final Properties appProperties;
+
+    /**
+     * Builds the HL7 V2 MLLP URI using the following properties:
+     * <ul>
+     *     <li>idaas.connect.endpoint.hl7_v2_mllp.baseUri</li>
+     *     <li>idaas.connect.endpoint.hl7_v2_mllp.options</li>
+     * </ul>
+     * @return the HL7 V2 MLLP URI
+     */
+    public String getHl7V2MllpUri() {
+        return appProperties.getProperty(HL7_V2_MLLP_BASE_URI_PROP_KEY)
+                .concat("?")
+                .concat(appProperties.getProperty(HL7_V2_MLLP_OPTIONS_PROP_KEY, ""));
+    }
+
+    /**
+     * Builds the FHIR R4 Rest URI using the following properties:
+     * <ul>
+     *     <li>idaas.connect.endpoint.fhir_r4_rest.baseUri</li>
+     *     <li>idaas.connect.endpoint.fhir_r4_rest.options</li>
+     * </ul>
+     * @return the FHIR R4 Rest URI
+     */
+    public String getFhirR4RestUri() {
+        return appProperties.getProperty(FHIR_R4_REST_BASE_URI_PROP_KEY);
+    }
+
+    /**
+     * Builds the external FHIR R4 Rest URI for a resource using the following properties:
+     * <ul>
+     *     <li>idaas.connect.endpoint.external_fhir_r4_rest.baseUri</li>
+     *     <li>idaas.connect.endpoint.external_fhir_r4_rest.options</li>
+     * </ul>
+     * @param resourceType the FHIR resource type
+     * @return the FHIR R4 Rest URI
+     */
+    public String getExternalFhirR4RestUri(String resourceType) {
+        String externalFhirBaseUri = appProperties.getProperty(FHIR_R4_EXTERNAL_REST_BASE_URI_PROP_KEY);
+
+        if (externalFhirBaseUri == null || resourceType == null) {
+            return null;
+        }
+
+        return externalFhirBaseUri
+                .concat("/")
+                .concat(resourceType)
+                .concat("?")
+                .concat(appProperties.getProperty(FHIR_R4_EXTERNAL_REST_OPTIONS_PROP_KEY));
+    }
+
+    /**
+     * Builds a data store URI
+     * @param topicName The data store topic/segment for the URI
+     * @return the data store URI
+     */
+    public String getDataStoreUri(String topicName) {
+        return appProperties.getProperty(DATA_STORE_BASE_URI_PROP_KEY)
+                .concat(":")
+                .concat(topicName)
+                .concat("?")
+                .concat(appProperties.getProperty(DATA_STORE_OPTIONS_PROP_KEY));
+    }
+
+    public EndpointUriBuilder(Properties appProperties) {
+        this.appProperties = appProperties;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,11 @@
-# HL7-MLLP
+# HL7 V2 MLLP
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
 idaas.connect.endpoint.hl7_v2_mllp.baseUri=netty:tcp://localhost:2575
 idaas.connect.endpoint.hl7_v2_mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
+
+# FHIR R4 REST
+idaas.connect.endpoint.fhir_r4_rest.baseUri=http://0.0.0.0:8080/fhir/r4
 
 # idaas data store
 idaas.connect.component.kafka=org.apache.camel.component.kafka.KafkaComponent

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,8 +1,11 @@
-# HL7-MLLP
+# HL7 V2 MLLP
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
 idaas.connect.endpoint.hl7_v2_mllp.baseUri=netty:tcp://localhost:2575
 idaas.connect.endpoint.hl7_v2_mllp.options=sync=true&encoders=#hl7encoder&decoders=#hl7decoder
+
+# FHIR R4 REST
+idaas.connect.endpoint.fhir_r4_rest.baseUri=http://0.0.0.0:8080/fhir/r4
 
 # idaas data store
 idaas.connect.component.kafka=org.apache.camel.component.kafka.KafkaComponent

--- a/src/test/resources/route-validation-tests/hl7-mllp.properties
+++ b/src/test/resources/route-validation-tests/hl7-mllp.properties
@@ -1,4 +1,4 @@
-# HL7-MLLP
+# HL7 V2 MLLP
 idaas.connect.component.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 idaas.connect.component.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
 idaas.connect.endpoint.hl7_v2_mllp.baseUri=netty:tcp://localhost:2575


### PR DESCRIPTION
fixes #18 
This PR adds support for FHIR R4 Messaging using a dynamic processing route. The PR also includes a new EndpointUriBuilder which is used to parse application properties for use in Camel Endpoint URIs.